### PR TITLE
Bumped minimal required version of base module.

### DIFF
--- a/info.json
+++ b/info.json
@@ -5,5 +5,5 @@
   "author": "MagmaMcFry",
   "description": "The official, improved rewrite of Factorissimo. Place down factory buildings, walk in, build your factories inside!",
   "factorio_version": "0.14",
-  "dependencies": ["base >= 0.14.0"]
+  "dependencies": ["base >= 0.14.15"]
 }


### PR DESCRIPTION
Due to use of surface.set_chunk_generated_status, which was introduced in 0.14.15, games crashes when factory is built on version less than 15.
https://wiki.factorio.com/Version_history/0.14.0#0.14.15