### PR TITLE
Update belt connection delays if belt prototype speeds change.

### DIFF
--- a/connections/belt.lua
+++ b/connections/belt.lua
@@ -93,7 +93,7 @@ Belt.connect = function (factory, cid, cpos, outside_entity, inside_entity)
 end
 
 Belt.recheck = function (conn)
-	return (conn.from.valid and conn.to.valid and conn.facing == get_conn_facing(conn.from, conn.to, opposite[conn.facing], conn.facing))
+	return (conn.from.valid and conn.to.valid and conn.facing == get_conn_facing(conn.from, conn.to, opposite[conn.facing], conn.facing) and delays == calc_delays(conn.from.prototype.belt_speed, conn.to.prototype.belt_speed))
 end
 
 Belt.direction = function (conn)

--- a/updates.lua
+++ b/updates.lua
@@ -103,5 +103,10 @@ Updates.run = function()
 			if gui then gui.destroy() end
 		end
 	end
+
+	--Check that all connections are still correct given any changes other mods may have made.
+	for _, factory in pairs(global.factories) do
+		Connections.recheck_factory(factory, nil, nil)
+	end
 	global.update_version = 8
 end


### PR DESCRIPTION
This change makes the mod recheck all factory connections if the configuration has changed, and adds a check to belt connections to make sure the delays are accurate. This allows the delays to be automatically shortened if another mod increases the belt speeds which would otherwise result in reduced throughput on the connections.

I believe that the recheck_factory function is safe and reasonable to run once if the game is loaded after mod configurations change, and that it is reasonable for the belt connection recheck function to verify that the stored delays are still valid.