### PR TITLE
Update to 0.17

### DIFF
--- a/connections/fluid.lua
+++ b/connections/fluid.lua
@@ -123,7 +123,7 @@ local function transfer(from, to, from_cap, to_cap)
 	local to_box = to_boxes[1]
 	if from_box ~= nil then
 		if to_box == nil then 
-			if from_box.amount < to_cap then
+			if from_box.amount <= to_cap then
 				from_boxes[1] = nil
 				to_boxes[1] = from_box
 			else
@@ -134,7 +134,7 @@ local function transfer(from, to, from_cap, to_cap)
 			end
 		elseif to_box.name == from_box.name then
 			local total = from_box.amount + to_box.amount
-			if total < to_cap then
+			if total <= to_cap then
 				from_boxes[1] = nil
 				to_box.temperature = (from_box.amount*from_box.temperature + to_box.amount*to_box.temperature)/total
 				to_box.amount = to_box.amount + from_box.amount

--- a/control.lua
+++ b/control.lua
@@ -821,7 +821,7 @@ script.on_event(defines.events.on_marked_for_deconstruction, function(event)
 end)
 
 -- Factories also need to start working again once they are unmarked
-script.on_event(defines.events.on_canceled_deconstruction, function(event)
+script.on_event(defines.events.on_cancelled_deconstruction, function(event)
 	local entity = event.entity
 	if global.saved_factories[entity.name] then
 		-- Rebuild factory from save
@@ -867,7 +867,7 @@ end)
 local function get_camera_toggle_button(player)
 	local buttonflow = mod_gui.get_button_flow(player)
 	local button = buttonflow.factory_camera_toggle_button or buttonflow.add{type="sprite-button", name="factory_camera_toggle_button", sprite="technology/factory-architecture-t1"}
-	button.style.visible = player.force.technologies["factory-preview"].researched
+	button.visible = player.force.technologies["factory-preview"].researched
 	return button
 end
 
@@ -876,7 +876,7 @@ local function get_camera_frame(player)
 	local camera_frame = frameflow.factory_camera_frame
 	if not camera_frame then
 		camera_frame = frameflow.add{type = "frame", name = "factory_camera_frame", style = "captionless_frame"}
-		camera_frame.style.visible = false
+		camera_frame.visible = false
 	end
 	return camera_frame
 end
@@ -918,11 +918,11 @@ local function set_camera(player, factory, inside)
 		camera.style.minimal_width = preview_size
 		camera.style.minimal_height = preview_size
 	end
-	camera_frame.style.visible = true
+	camera_frame.visible = true
 end
 
 local function unset_camera(player)
-	get_camera_frame(player).style.visible = false
+	get_camera_frame(player).visible = false
 end
 
 local function update_camera(player)

--- a/info.json
+++ b/info.json
@@ -4,6 +4,6 @@
   "title": "Factorissimo2",
   "author": "MagmaMcFry",
   "description": "The official, improved rewrite of Factorissimo. Place down factory buildings, walk in, build your factories inside!",
-  "factorio_version": "0.16",
+  "factorio_version": "0.17",
   "dependencies": ["base >= 0.16.0"]
 }

--- a/prototypes/component.lua
+++ b/prototypes/component.lua
@@ -102,8 +102,10 @@ local VALID_POWER_TRANSFER_RATES = {1,2,5,10,20,50,100,200,500,1000,2000,5000,10
 
 function make_energy_interfaces(size,passive_input,passive_output,icon)
 	local j = size/2-0.3
-	local input_priority = (passive_input and "terciary") or "secondary-input"
-	local output_priority = (passive_output and "terciary") or "secondary-output"
+	-- local input_priority = (passive_input and "terciary") or "secondary-input"
+	-- local output_priority = (passive_output and "terciary") or "secondary-output"
+	local input_priority  = "secondary-input"
+	local output_priority = "secondary-output"
 	for _, transfer_rate in pairs(VALID_POWER_TRANSFER_RATES) do
 		local buffer_size = transfer_rate*16667*power_batch_size
 		data:extend({
@@ -285,10 +287,10 @@ data:extend({
 		pictures = {
 			filename = "__base__/graphics/entity/substation/substation.png",
 			priority = "high",
-			width = 132,
-			height = 144,
+			width = 70,
+			height = 136,
 			direction_count = 4,
-			shift = {0.9, -1}
+			shift = util.by_pixel(0, 1-32)
 		},
 		radius_visualisation_picture = {
 			filename = "__base__/graphics/entity/small-electric-pole/electric-pole-radius-visualization.png",
@@ -331,7 +333,7 @@ data:extend({
 		circuit_connector_sprites = circuit_connector_definitions["lamp"].sprites,
 		circuit_wire_max_distance = 0,
 	},
-	
+
 	{
 		type = "container",
 		name = "factory-overlay-controller",
@@ -352,8 +354,8 @@ data:extend({
 		picture = {
 			filename = "__base__/graphics/entity/iron-chest/iron-chest.png",
 			priority = "extra-high",
-			width = 48,
-			height = 34,
+			width = 34,
+			height = 38,
 			shift = {0.1875, 0}
 		},
 		circuit_wire_connection_point = circuit_connector_definitions["chest"].points,

--- a/prototypes/factory.lua
+++ b/prototypes/factory.lua
@@ -34,7 +34,7 @@ local factory_1 = function(suffix, localised_suffix, result_suffix, visible, cou
 	local localised_name = {"entity-name.factory-1" .. localised_suffix}
 	local result_name = "factory-1" .. result_suffix
 	local item_flags
-	if visible then item_flags = {"goes-to-quickbar"} else item_flags = {"hidden"} end
+	if visible then item_flags = {} else item_flags = {"hidden"} end
 	return {
 		{
 			type = "storage-tank",
@@ -96,7 +96,7 @@ local factory_2 = function(suffix, localised_suffix, result_suffix, visible, cou
 	local localised_name = {"entity-name.factory-2" .. localised_suffix}
 	local result_name = "factory-2" .. result_suffix
 	local item_flags
-	if visible then item_flags = {"goes-to-quickbar"} else item_flags = {"hidden"} end
+	if visible then item_flags = {} else item_flags = {"hidden"} end
 	return {
 		{
 			type = "storage-tank",
@@ -158,7 +158,7 @@ local factory_3 = function(suffix, localised_suffix, result_suffix, visible, cou
 	local localised_name = {"entity-name.factory-3" .. localised_suffix}
 	local result_name = "factory-3" .. result_suffix
 	local item_flags
-	if visible then item_flags = {"goes-to-quickbar"} else item_flags = {"hidden"} end
+	if visible then item_flags = {} else item_flags = {"hidden"} end
 	return {
 		{
 			type = "storage-tank",
@@ -221,7 +221,7 @@ for i=10,99 do
 	data:extend(factory_1("-s" .. i, "-s", "-s" .. i, false, 1, F.."/graphics/factory/factory-1-combined.png"))
 end
 data:extend(factory_1("-i", "-i", "", false, 1, F.."/graphics/factory/factory-1-combined.png"))
-	
+
 data:extend({
 	{
 		type = "simple-entity",

--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -16,7 +16,7 @@ data:extend({
 		},
 		unit = {
 			count = easy_research and 30 or 200,
-			ingredients = {{"science-pack-1", 1}},
+			ingredients = {{"automation-science-pack", 1}},
 			time = 30
 		},
 		order = pf.."a-a",
@@ -35,7 +35,7 @@ data:extend({
 		},
 		unit = {
 			count = easy_research and 100 or 600,
-			ingredients = {{"science-pack-1", 1},{"science-pack-2", 1}},
+			ingredients = {{"automation-science-pack", 1},{"logistic-science-pack", 1}},
 			time = 45
 		},
 		order = pf.."a-b",
@@ -54,12 +54,12 @@ data:extend({
 		},
 		unit = {
 			count = easy_research and 300 or 2000,
-			ingredients = {{"science-pack-1", 1},{"science-pack-2", 1},{"science-pack-3", 1}},
+			ingredients = {{"automation-science-pack", 1},{"logistic-science-pack", 1},{"chemical-science-pack", 1}},
 			time = 60
 		},
 		order = pf.."a-c",
 	},
-	
+
 	-- Connection types
 	{
 		type = "technology",
@@ -73,7 +73,7 @@ data:extend({
 		},
 		unit = {
 			count = easy_research and 10 or 100,
-			ingredients = {{"science-pack-1", 1}},
+			ingredients = {{"automation-science-pack", 1}},
 			time = 30
 		},
 		order = pf.."b-a",
@@ -87,7 +87,7 @@ data:extend({
 		effects = {},
 		unit = {
 			count = easy_research and 20 or 200,
-			ingredients = {{"science-pack-1", 1},{"science-pack-2", 1}},
+			ingredients = {{"automation-science-pack", 1},{"logistic-science-pack", 1}},
 			time = 30
 		},
 		order = pf.."b-b",
@@ -104,14 +104,14 @@ data:extend({
 		},
 		unit = {
 			count = easy_research and 30 or 300,
-			ingredients = {{"science-pack-1", 1},{"science-pack-2", 1},{"science-pack-3", 1}},
+			ingredients = {{"automation-science-pack", 1},{"logistic-science-pack", 1},{"chemical-science-pack", 1}},
 			time = 30
 		},
 		order = pf.."b-c",
 	},
-	
+
 	-- Interior upgrades
-	
+
 	{
 		type = "technology",
 		name = "factory-interior-upgrade-lights",
@@ -121,7 +121,7 @@ data:extend({
 		effects = {},
 		unit = {
 			count = easy_research and 5 or 50,
-			ingredients = {{"science-pack-1", 1}},
+			ingredients = {{"automation-science-pack", 1}},
 			time = 30
 		},
 		order = pf.."c-a",
@@ -135,13 +135,13 @@ data:extend({
 		effects = {},
 		unit = {
 			count = easy_research and 10 or 100,
-			ingredients = {{"science-pack-1", 1},{"science-pack-2", 1}},
+			ingredients = {{"automation-science-pack", 1},{"logistic-science-pack", 1}},
 			time = 30
 		},
 		order = pf.."c-b",
 	},
 	-- Misc utilities
-	
+
 	{
 		type = "technology",
 		name = "factory-preview",
@@ -151,7 +151,7 @@ data:extend({
 		effects = {},
 		unit = {
 			count = easy_research and 20 or 200,
-			ingredients = {{"science-pack-1", 1},{"science-pack-2", 1}},
+			ingredients = {{"automation-science-pack", 1},{"logistic-science-pack", 1}},
 			time = 30
 		},
 		order = pf.."d-a",
@@ -167,14 +167,14 @@ data:extend({
 		},
 		unit = {
 			count = easy_research and 20 or 100,
-			ingredients = {{"science-pack-1", 1},{"science-pack-2", 1},{"science-pack-3", 1}},
+			ingredients = {{"automation-science-pack", 1},{"logistic-science-pack", 1},{"chemical-science-pack", 1}},
 			time = 30
 		},
 		order = pf.."d-b",
 	},
-	
+
 	-- Recursion!
-	
+
 	{
 		type = "technology",
 		name = "factory-recursion-t1",
@@ -184,7 +184,7 @@ data:extend({
 		effects = {},
 		unit = {
 			count = easy_research and 200 or 2000,
-			ingredients = {{"science-pack-1", 1},{"science-pack-2", 1}},
+			ingredients = {{"automation-science-pack", 1},{"logistic-science-pack", 1}},
 			time = 60
 		},
 		order = pf.."e-a",
@@ -198,7 +198,7 @@ data:extend({
 		effects = {},
 		unit = {
 			count = easy_research and 500 or 5000,
-			ingredients = {{"science-pack-1", 1},{"science-pack-2", 1},{"science-pack-3", 1}},
+			ingredients = {{"automation-science-pack", 1},{"logistic-science-pack", 1},{"chemical-science-pack", 1}},
 			time = 60
 		},
 		order = pf.."e-b",

--- a/prototypes/utility.lua
+++ b/prototypes/utility.lua
@@ -4,14 +4,14 @@ require("circuit-connector-sprites")
 
 -- Pipe connectors
 
-local function factory_pipe(name, height, order) 
+local function factory_pipe(name, height, order)
 	data:extend({
 		{
 			type = "item",
 			name = name,
 			icon = F.."/graphics/icon/"..name..".png",
 			icon_size = 32,
-			flags = {"goes-to-quickbar"},
+			flags = {},
 			subgroup = "factorissimo2",
 			order = order,
 			place_result = name,
@@ -53,26 +53,26 @@ local function factory_pipe(name, height, order)
 				fluid_background = {
 					filename = "__base__/graphics/entity/storage-tank/fluid-background.png",
 					priority = "extra-high",
-					width = 0,
-					height = 0
+					width = 1,
+					height = 1
 				},
 				window_background = {
 					filename = "__base__/graphics/entity/storage-tank/window-background.png",
 					priority = "extra-high",
-					width = 0,
-					height = 0
+					width = 1,
+					height = 1
 				},
 				flow_sprite = {
 					filename = "__base__/graphics/entity/pipe/fluid-flow-low-temperature.png",
 					priority = "extra-high",
-					width = 0,
-					height = 0
+					width = 1,
+					height = 1
 				},
 				gas_flow = {
 					filename = "__base__/graphics/entity/pipe/fluid-flow-low-temperature.png",
 					priority = "extra-high",
-					width = 0,
-					height = 0,
+					width = 1,
+					height = 1,
 					frame_count = 1,
 				}
 			},
@@ -104,7 +104,7 @@ data:extend({
 		name = "factory-circuit-input",
 		icon = F.."/graphics/icon/factory-circuit-input.png",
 		icon_size = 32,
-		flags = {"goes-to-quickbar"},
+		flags = {},
 		subgroup = "factorissimo2",
 		order = "c-a",
 		place_result = "factory-circuit-input",
@@ -119,16 +119,16 @@ data:extend({
 		minable = {mining_time = 1, result = "factory-circuit-input"},
 		max_health = 80,
 		corpse = "small-remnants",
-		
+
 		collision_box = {{-0.29, -0.29}, {0.29, 0.29}},
 		selection_box = {{-0.5, -0.5}, {0.5, 0.5}},
-		
+
 		fluid_box = {
 			base_area = 1,
 			pipe_covers = pipecoverspictures(),
 			pipe_connections = {},
 		},
-		
+
 		energy_source = {
 			type = "electric",
 			usage_priority = "secondary-input",
@@ -226,13 +226,13 @@ data:extend({
 		},
 		circuit_wire_max_distance = 7.5
 	},
-	
+
 	{
 		type = "item",
 		name = "factory-circuit-output",
 		icon = F.."/graphics/icon/factory-circuit-output.png",
 		icon_size = 32,
-		flags = {"goes-to-quickbar"},
+		flags = {},
 		subgroup = "factorissimo2",
 		order = "c-b",
 		place_result = "factory-circuit-output",
@@ -298,7 +298,7 @@ data:extend({
 				height = 6,
 				frame_count = 1,
 				shift = util.by_pixel(9, -12),
-				
+
 			},
 			east = {
 				filename = "__base__/graphics/entity/combinator/activity-leds/constant-combinator-LED-E.png",
@@ -306,7 +306,7 @@ data:extend({
 				height = 8,
 				frame_count = 1,
 				shift = util.by_pixel(8, 0),
-				
+
 			},
 			south = {
 				filename = "__base__/graphics/entity/combinator/activity-leds/constant-combinator-LED-S.png",
@@ -314,7 +314,7 @@ data:extend({
 				height = 8,
 				frame_count = 1,
 				shift = util.by_pixel(-9, 2),
-				
+
 			},
 			west = {
 				filename = "__base__/graphics/entity/combinator/activity-leds/constant-combinator-LED-W.png",
@@ -322,7 +322,7 @@ data:extend({
 				height = 8,
 				frame_count = 1,
 				shift = util.by_pixel(-7, -15),
-				
+
 			},
 		},
 
@@ -389,7 +389,7 @@ data:extend({
 		name = "factory-requester-chest",
 		icon = F.."/graphics/icon/factory-requester-chest.png",
 		icon_size = 32,
-		flags = {"goes-to-quickbar"},
+		flags = {},
 		subgroup = "factorissimo2",
 		order = "d-a",
 		place_result = "factory-requester-chest",


### PR DESCRIPTION
Had some free time today so I figured I'd try out porting this to 0.17. I tested it out with a large factory that made heavy use of it in 0.16 and I believe I've pretty much covered everything (hopefully). 

The only things left that I think could maybe use some work is: 

- Updating the factory input/output pipes to use the new HR texture normal pipes use

- Maybe updating the tech path to reflect the new tech tree changes? Not even sure if that is really necessary. 

- Changing the factory overlay chests from iron to steel since the new iron chests looks kinda funky and are no longer square
