### PR TITLE
Fix factoriomaps API name mismatch

### DIFF
--- a/compat/factoriomaps.lua
+++ b/compat/factoriomaps.lua
@@ -46,6 +46,6 @@ end
 
 function Compat.handle_factoriomaps()
 	if remote.interfaces.factoriomaps then
-		script.on_event(remote.call("factoriomaps", "get_start_capture_event_id"), cleanup_entities_for_factoriomaps)
+		script.on_event(remote.call("factoriomaps", "get_start_capture_event"), cleanup_entities_for_factoriomaps)
 	end
 end


### PR DESCRIPTION
My factorissimo-factoriomap compatibility is broken due to API name mismatch.
I've done something wrong with other mods, or this commit will fix the issue.