### PR TITLE
Allow larger buildings inside smaller buildings when Free recursion is enabled.

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -693,9 +693,10 @@ end)
 local function can_place_factory_here(tier, surface, position)
 	local factory = find_surrounding_factory(surface, position)
 	if not factory then return true end
+	if settings.global["Factorissimo2-free-recursion"].value then return true end
 	local outer_tier = factory.layout.tier
-	if outer_tier > tier and (factory.force.technologies["factory-recursion-t1"].researched or settings.global["Factorissimo2-free-recursion"].value) then return true end
-	if outer_tier >= tier and (factory.force.technologies["factory-recursion-t2"].researched or settings.global["Factorissimo2-free-recursion"].value) then return true end
+	if outer_tier > tier and factory.force.technologies["factory-recursion-t1"].researched then return true end
+	if outer_tier >= tier and factory.force.technologies["factory-recursion-t2"].researched then return true end
 	if outer_tier > tier then
 		surface.create_entity{name="flying-text", position=position, text={"factory-connection-text.invalid-placement-recursion-1"}, force = factory.force}
 	elseif outer_tier >= tier then


### PR DESCRIPTION
As a player, I am often looking for access to this specific mechanic (putting larger buildings inside smaller buildings) but it's not currently permitted by Factorissimo. 

This seemed like a good simple way to add that ability.