### PR TITLE
Overlay rework

### DIFF
--- a/prototypes/component.lua
+++ b/prototypes/component.lua
@@ -364,6 +364,7 @@ data:extend({
 		icon_size = 32,
 		flags = {"not-on-map"},
 		minable = nil,
+		selectable_in_game = false,
 		max_health = 100,
 		corpse = "small-remnants",
 		collision_box = {{-1.85, -1.85}, {1.85, 1.85}},

--- a/prototypes/component.lua
+++ b/prototypes/component.lua
@@ -36,6 +36,15 @@ local function ps()
 	}
 end
 
+local function blank_sprites()
+	return {
+		north = blank(),
+		south = blank(),
+		east = blank(),
+		west = blank()
+	}
+end
+
 local function blankpipepictures()
 	return {
 		straight_vertical_single = blank(),
@@ -349,7 +358,7 @@ data:extend({
 	},
 
 	{
-		type = "container",
+		type = "constant-combinator",
 		name = "factory-overlay-display",
 		icon = "__base__/graphics/icons/iron-chest.png",
 		icon_size = 32,
@@ -357,20 +366,15 @@ data:extend({
 		minable = nil,
 		max_health = 100,
 		corpse = "small-remnants",
-		open_sound = { filename = "__base__/sound/metallic-chest-open.ogg", volume=0.65 },
-		close_sound = { filename = "__base__/sound/metallic-chest-close.ogg", volume = 0.7 },
-		resistances = {},
 		collision_box = {{-1.85, -1.85}, {1.85, 1.85}},
 		collision_mask = {},
 		selection_box = {{-2, -2}, {2, 2}},
-		selectable_in_game = false,
-		scale_info_icons = true,
-		inventory_size = 4,
-		vehicle_impact_sound =	{ filename = "__base__/sound/car-metal-impact.ogg", volume = 0.65 },
-		picture = blank(),
-		circuit_wire_connection_point = circuit_connector_definitions["chest"].points,
-		circuit_connector_sprites = circuit_connector_definitions["chest"].sprites,
-		circuit_wire_max_distance = 0
+		item_slot_count = 4,
+		sprites = blank_sprites(),
+		activity_led_sprites = blank_sprites(),
+		activity_led_light_offsets = {{0, 0}, {0, 0}, {0, 0}, {0, 0}},
+		circuit_wire_connection_points = circuit_connector_definitions["storage-tank"].points,
+		circuit_wire_max_distance = 0,
 	},
 	{
 		type = "mining-drill",


### PR DESCRIPTION
This is new factory overlay system that makes it possible to set fluids as an overlay icon.
It makes some improvements:

- allows using fluids as an overlay icons (for factories that produce/consume fluids),
- allows using virtual signals as overlay icons (maybe for factory identification),
- doesn't use chests for overlay (so fixes #56),
- doesn't require item to be actually inserted to any container (which might matter for expensive/not yet accessible items).

The only drawback I know of is that the system is made on constant combinators, so requires players to enable "show combinator settings in alt-mode" (disabled by default).

I haven't touched conversion from the old system yet, but I presume that shouldn't be too hard to do. Also for now overlay can only be changed from the outside of a factory.

Please let me know if this makes sense and what else needs to be done.